### PR TITLE
AWS Node Termination Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This package deploys everything nessesary for an opperational eks cluster includ
     -   Cert Manager configured for lets encrypt
     -   Traefik as Ingress Controller
     -   External DNS for dynamic configuration of route53 records from Ingress objects
+    -   AWS Node Termination Handler to ensure we can gracefully stop services if SPOT instances are preempted 
     -   A simple Hello World app at `helloworld.<rootDomainName>` to see that all components are working correctly
 
 ## Additional Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shapeshiftoss/cluster-launcher",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "license": "MIT",
     "main": "dist/index.js",
     "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@pulumi/pulumi": "3.11.0"
     },
     "devDependencies": {
-        "@types/node": "14.16.0"
+        "@types/node": "^14.14.7"
     },
     "prettier": {
         "tabWidth": 4,

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -19,7 +19,7 @@ interface ClusterArgs {
     enabledClusterAutoscaler: boolean
 }
 
-export default async (name: string, args: ClusterArgs, opts: ComponentResourceOptionsWithProvider) => {
+export default async function (name: string, args: ClusterArgs, opts: ComponentResourceOptionsWithProvider) {
     const tags = { iac: `pulumi-${name}` }
 
     const privateSubnets = await args.vpc.privateSubnets

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as pulumi from '@pulumi/pulumi'
 import * as externalDNS from './externalDNS'
 import * as helloWorld from './helloWorld'
 import * as traefik from './traefik'
+import * as nodeTerminationHandler from './nodeTerminationHandler'
 import createCluster from './cluster'
 import * as crds from './crds'
 import * as autoscaler from './clusterAutoscaler'
@@ -203,6 +204,16 @@ export class EKSClusterLauncher extends pulumi.ComponentResource {
         const zone = await aws.route53.getZone(
             { name: argsWithDefaults.rootDomainName },
             { ...opts, provider: awsProvider }
+        )
+
+        new nodeTerminationHandler.Deployment(
+            name,
+            {
+                cluster: cluster,
+                namespace: namespace,
+                providers: { aws: awsProvider, k8s: k8sProvider }
+            },
+            opts
         )
 
         new externalDNS.Deployment(

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ export class EKSClusterLauncher extends pulumi.ComponentResource {
             {
                 cluster: cluster,
                 namespace: namespace,
-                providers: { aws: awsProvider, k8s: k8sProvider }
+                providers: { k8s: k8sProvider }
             },
             opts
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,16 +210,20 @@ export class EKSClusterLauncher extends pulumi.ComponentResource {
             name,
             {
                 cluster: cluster,
-                namespace: namespace,
-                providers: { k8s: k8sProvider }
+                namespace: namespace
             },
-            opts
+            { ...opts, provider: k8sProvider }
         )
 
         new externalDNS.Deployment(
             name,
-            { cluster, namespace, zone: zone as unknown as aws.route53.Zone, awsProvider },
-            { ...opts, provider: k8sProvider }
+            {
+                cluster: cluster,
+                namespace,
+                zone: zone as unknown as aws.route53.Zone,
+                providers: { aws: awsProvider, k8s: k8sProvider }
+            },
+            opts
         )
 
         if (argsWithDefaults.autoscaling.enabled)

--- a/src/nodeTerminationHandler.ts
+++ b/src/nodeTerminationHandler.ts
@@ -5,7 +5,6 @@ import { Cluster } from '@pulumi/eks'
 export interface deploymentArgs {
     namespace: pulumi.Input<string>
     cluster: Cluster
-    providers: { k8s: k8s.Provider }
 }
 
 export class Deployment extends k8s.helm.v3.Chart {
@@ -25,10 +24,10 @@ export class Deployment extends k8s.helm.v3.Chart {
                     podTerminationGracePeriod: '-1', //If negative, use value defined in pod
                     nodeTerminationGracePeriod: '120',
                     enablePrometheusServer: 'false', //For later use
-                    emitKubernetesEvents: 'false', //For later use
+                    emitKubernetesEvents: 'false' //For later use
                 }
             },
-            { ...opts, parent: args.cluster, provider: args.providers.k8s }
+            { ...opts, parent: args.cluster }
         )
     }
 }

--- a/src/nodeTerminationHandler.ts
+++ b/src/nodeTerminationHandler.ts
@@ -1,0 +1,35 @@
+import * as aws from '@pulumi/aws'
+import * as k8s from '@pulumi/kubernetes'
+import * as pulumi from '@pulumi/pulumi'
+import { Cluster } from '@pulumi/eks'
+
+export interface deploymentArgs {
+    namespace: pulumi.Input<string>
+    cluster: Cluster
+    providers: { aws: aws.Provider; k8s: k8s.Provider }
+}
+
+export class Deployment extends k8s.helm.v3.Chart {
+    constructor(name: string, args: deploymentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super(
+            `${name}-node-termination-handler`,
+            {
+                // https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler
+                chart: 'aws-node-termination-handler',
+                repo: 'eks',
+                namespace: args.namespace,
+                version: '0.15.3',
+                values: {
+                    enableSpotInterruptionDraining: 'true',
+                    enableRebalanceDraining: 'false',
+                    enableScheduledEventDraining: 'false', //Experimental feature
+                    podTerminationGracePeriod: '-1', //If negative, use value defined in pod
+                    nodeTerminationGracePeriod: '120',
+                    enablePrometheusServer: 'false', //For later use
+                    emitKubernetesEvents: 'false', //For later use
+                }
+            },
+            { ...opts, parent: args.cluster, provider: args.providers.k8s }
+        )
+    }
+}

--- a/src/nodeTerminationHandler.ts
+++ b/src/nodeTerminationHandler.ts
@@ -1,4 +1,3 @@
-import * as aws from '@pulumi/aws'
 import * as k8s from '@pulumi/kubernetes'
 import * as pulumi from '@pulumi/pulumi'
 import { Cluster } from '@pulumi/eks'
@@ -6,7 +5,7 @@ import { Cluster } from '@pulumi/eks'
 export interface deploymentArgs {
     namespace: pulumi.Input<string>
     cluster: Cluster
-    providers: { aws: aws.Provider; k8s: k8s.Provider }
+    providers: { k8s: k8s.Provider }
 }
 
 export class Deployment extends k8s.helm.v3.Chart {

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,7 +67,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@pulumi/aws@^4.0.0":
+"@pulumi/aws@4.17.0", "@pulumi/aws@^4.0.0":
   version "4.17.0"
   resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-4.17.0.tgz#13c349a55bb649e2943c0b84ea471906f45284df"
   integrity sha512-avwyzCYRUGmnjFqvd6eUq2xJY1q9w2Y9aJIb79aFaWCmhUuKrCduFkzf9S+0fP0pnywmLaaROhOB4Ciavc6jAg==
@@ -79,7 +79,7 @@
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/awsx@^0.31.0":
+"@pulumi/awsx@0.31.0":
   version "0.31.0"
   resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.31.0.tgz#f77368ccbdd76d21782d715f5a88029e5c65c57f"
   integrity sha512-Z8WDMO0rpwPIACy0oD3m80DdHE+0/wFtBy5YdPiieMr4CekohOfc83BTix3U5dDfv6XCtEsMI+VzZvgYUM1e4w==
@@ -96,7 +96,7 @@
     "@pulumi/pulumi" "^3.0.0"
     semver "^5.4.0"
 
-"@pulumi/eks@^0.32.0":
+"@pulumi/eks@0.32.0":
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/@pulumi/eks/-/eks-0.32.0.tgz#c0ca72b1d0bacb4cb83a71e74300dee344b77bf4"
   integrity sha512-7z+FyhSQAbWC7sCoXDWKroDTe/8DcNVF7KxBzQIgqUaHDcAP1u0fpD6nutiNgmCY/cqsYrhPPgwgZTRQTxHPxw==
@@ -124,10 +124,31 @@
     shell-quote "^1.6.1"
     tmp "^0.0.33"
 
-"@pulumi/kubernetesx@^0.1.6":
+"@pulumi/kubernetesx@0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@pulumi/kubernetesx/-/kubernetesx-0.1.6.tgz#61518ae6a7d37c17998561b8d5290546815bad1d"
   integrity sha512-9VL4Yi4b4aLC/obBarJuNkm86kABByUZICYPSTdV396MGZtOc066o2brsB+kWVQcVfkYVXTPrpjIkAwBXXnzGw==
+
+"@pulumi/pulumi@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.11.0.tgz#49f748d945943f16b255193241bcb7dbf194e26f"
+  integrity sha512-btAPDbTKjvUwNFo7Vo5KTHZw5IRvSYMLRafSU1zE0EXr1h7U4LWc+wpbjHxWLd2r8vTyW+rf1imWSEqWcYkjYg==
+  dependencies:
+    "@grpc/grpc-js" "^1.2.7"
+    "@logdna/tail-file" "^2.0.6"
+    "@pulumi/query" "^0.3.0"
+    google-protobuf "^3.5.0"
+    js-yaml "^3.14.0"
+    minimist "^1.2.0"
+    normalize-package-data "^2.4.0"
+    protobufjs "^6.8.6"
+    read-package-tree "^5.3.1"
+    require-from-string "^2.0.1"
+    semver "^6.1.0"
+    source-map-support "^0.4.16"
+    ts-node "^7.0.1"
+    typescript "~3.7.3"
+    upath "^1.1.0"
 
 "@pulumi/pulumi@^3.0.0":
   version "3.10.3"
@@ -191,10 +212,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.0.tgz#f0374c4e89d1fc1ef705caad3021ba34c1a9294c"
   integrity sha512-e66BrnjWQ3BRBZ2+iA5e85fcH9GLNe4S0n1H0T3OalK2sXg5XWEFTO4xvmGrYQ3edy+q6fdOh5t0/HOY8OAqBg==
 
-"@types/node@^10.0.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+"@types/node@^14.14.7":
+  version "14.17.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.18.tgz#0198489a751005f71217744aa966cd1f29447c81"
+  integrity sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==
 
 "@types/tmp@^0.0.33":
   version "0.0.33"


### PR DESCRIPTION
We have discovered that Bitcoin node volumes are being corrupted due to spot instances being preempted.  

The [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) is designed to monitor EC2 instance metadata and take action when an instance is scheduled for removal.

This PR installs the [helm chart](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler) of this handler.

