### PR TITLE
Prometheus Scrape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shapeshiftoss/cluster-launcher",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "license": "MIT",
     "main": "dist/index.js",
     "source": "src/index.ts",

--- a/src/clusterAutoscaler.ts
+++ b/src/clusterAutoscaler.ts
@@ -34,6 +34,10 @@ export class Deployment extends k8s.helm.v3.Chart {
                         'skip-nodes-with-system-pods': false,
                         'max-graceful-termination-sec': '600' //Amount of time to allow a pod to terminate before killing
                     },
+                    podAnnotations: {
+                        'prometheus.io/port':'8085',
+                        'prometheus.io/scrape':'true',
+                    },
                     resources: {
                         limits: {
                             cpu: '300m',

--- a/src/traefik.ts
+++ b/src/traefik.ts
@@ -122,7 +122,11 @@ export class Deployment extends k8s.helm.v3.Chart {
                         minAvailable: 2
                     },
                     deployment: {
-                        replicas: args.replicas
+                        replicas: args.replicas,
+                        podAnnotations: {
+                            'prometheus.io/port': '9100',
+                            'prometheus.io/scrape': 'true'
+                        }
                     }
                 },
                 transformations: [


### PR DESCRIPTION
In order to support the new unchained monitoring stack, we're going to expose metrics of cluster-autoscaler and traefik so that Prometheus can discover/scrape.

Ref:
https://github.com/shapeshift/unchained/pull/154