### PR TITLE
Multiple Node Groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shapeshiftoss/cluster-launcher",
-    "version": "0.6.8",
+    "version": "0.6.9",
     "license": "MIT",
     "main": "dist/index.js",
     "source": "src/index.ts",


### PR DESCRIPTION
This PR adds the ability to define a list of node groups that will be created. This functionality is required to perform graceful node group migrations, as well as the ability to utilize multiple capacity types (SPOT, ON_DEMAND).  